### PR TITLE
replaced the previous deployed url with the official domain link

### DIFF
--- a/src/app/docs/[[...slug]]/page.client.tsx
+++ b/src/app/docs/[[...slug]]/page.client.tsx
@@ -70,7 +70,7 @@ const optionVariants = cva(
 );
 
 export function ViewOptions(props: { markdownUrl: string; githubUrl: string }) {
-  const markdownUrl = new URL(props.markdownUrl, "https://devfolio-docs.vercel.app");
+  const markdownUrl = new URL(props.markdownUrl, "https://guide.devfolio.co");
   const q = `Read ${markdownUrl}, I want to ask questions about it.`;
 
   const claude = `https://claude.ai/new?${new URLSearchParams({


### PR DESCRIPTION

This PR includes the following update:

Replaced the previously deployed URL (`devfolio-docs.vercel.app`) with the official domain link: [`guide.devfolio.co`](https://guide.devfolio.co/)

This ensures consistency across the guide and reflects the current production deployment.